### PR TITLE
Update HTTP examples to use /api/games

### DIFF
--- a/GameLibrary.Api/GameLibrary.Api.http
+++ b/GameLibrary.Api/GameLibrary.Api.http
@@ -1,6 +1,33 @@
 @GameLibrary.Api_HostAddress = http://localhost:5182
 
-GET {{GameLibrary.Api_HostAddress}}/weatherforecast/
+GET {{GameLibrary.Api_HostAddress}}/api/games
 Accept: application/json
+
+###
+
+POST {{GameLibrary.Api_HostAddress}}/api/games
+Content-Type: application/json
+# Authorization: Bearer YOUR_TOKEN
+
+{
+  "name": "Example Game",
+  "studio": "Example Studio",
+  "coverImageUrl": "https://example.com/image.png",
+  "price": 49.99,
+  "description": "A fun game to play.",
+  "steamLink": "https://store.steampowered.com/app/example"
+}
+
+###
+
+PUT {{GameLibrary.Api_HostAddress}}/api/games/1
+Content-Type: application/json
+# Authorization: Bearer YOUR_TOKEN
+
+{
+  "name": "Updated Game Name",
+  "price": 39.99,
+  "description": "Updated description"
+}
 
 ###


### PR DESCRIPTION
## Summary
- update the sample HTTP file to call `/api/games`
- include example POST/PUT requests

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685acd9c6bd883238e9f6ddef53d78f2